### PR TITLE
fix documentation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@ This fabulous linen texture was integrated into the site design.
 
         <ul class="list more">
           <li class="corner"></li>
-          <li><a href="http://docs.couchdb.org/en/latest/">Documentation<span></span></a>
+          <li><a href="http://docs.couchdb.org">Documentation<span></span></a>
           <li><a href="https://cwiki.apache.org/confluence/display/COUCHDB/Current+Releases">Current Releases<span></span></a></li>
           <li><a href="http://blog.couchdb.org/">Blog<span></span></a>
           <li><a href="http://couchdb.apache.org/bylaws.html">Bylaws<span></span></a>


### PR DESCRIPTION
Top navigation link is pointing to an old version (1.6.1). Shouldn't this be changed to the latest (2.0.0), as in the bottom of the website? 

Bottom ref ![image](https://cloud.githubusercontent.com/assets/1150553/11610872/b16f4776-9ba8-11e5-806d-c8fe49f5c316.png)
