### PR TITLE
Fix Fauxton URL

### DIFF
--- a/developer-preview/2.0/index.html
+++ b/developer-preview/2.0/index.html
@@ -138,7 +138,7 @@ This fabulous linen texture was integrated into the site design.
       to listen on port 5984 and proxy to the nodes. You will have the CouchDB API available at port 5984 again.
     </p>
 
-    <p> To get started, visit Fauxton, the new web UI at <a href="http://127.0.0.1:15984/_utils">http://127.0.0.1:5984/_utils</a></p>
+    <p> To get started, visit Fauxton, the new web UI at <a href="http://127.0.0.1:5984/_utils">http://127.0.0.1:5984/_utils</a></p>
 
   </div>
 


### PR DESCRIPTION
The link text for the Fauxton URL says `http://127.0.0.1:5984/_utils` (port 5984), yet the actually hyperlink goes to `http://127.0.0.1:15984/_utils` (port 15984). This pull request fixes this error.
