### PR TITLE
Added coachapp mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,15 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
       </div>
 
       <div class="list-header">
+        <a href="http://mail-archives.apache.org/mod_mbox/couchapp/"><strong>CouchApp List</strong></a>
+        <a id="couchapp-mailing-list" class="hash-target">&nbsp;</a>
+        <a href="mailto:couchapp-subscribe@couchdb.apache.org">Subscribe</a> &middot;
+        <a href="mailto:couchapp@couchdb.apache.org">Post</a> &middot;
+        <a href="mailto:couchapp-unsubscribe@couchdb.apache.org">Unsubscribe</a>
+        <p>Questions about CoachApps? Discuss here about development of web applications served directly from CouchDB.</p>
+      </div>
+
+      <div class="list-header">
         <a href="http://mail-archives.apache.org/mod_mbox/couchdb-marketing/"><strong>Marketing List</strong></a>
         <a id="marketing-mailing-list" class="hash-target">&nbsp;</a>
         <a href="mailto:marketing-subscribe@couchdb.apache.org">Subscribe</a> &middot;


### PR DESCRIPTION
I added the CouchApp mailing list to the list of CoachDB mailing lists. Please note that the link archives link ( http://mail-archives.apache.org/mod_mbox/couchapp/ ) is not working. This should be fixed by the mailing list admin before merging.

CoachApp ML announcement: 
http://mail-archives.apache.org/mod_mbox/couchdb-user/201511.mbox/%3cCAHdjipK+0xx4uKW56E7O0QiJXJxxNtzTFNQ+CDVFR5CpZoOT2Q@mail.gmail.com%3e
