### PR TITLE
Nomi/bylaws

### DIFF
--- a/bylaws.html
+++ b/bylaws.html
@@ -11,89 +11,89 @@
 <p><em>This document was officially adopted by the CouchDB PMC as of 31 July 2014.</em></p>
 <p>A full changelog is available <a href="https://github.com/apache/couchdb-www/commits/asf-site/bylaws.html">on GitHub</a>.</p>
 
-<h2>Table of Contents</h2>
+<h2>Table of contents</h2>
 
 <div class="toc"></div>
 
 <h2 id="intro">1. Introduction</h2>
 
-<p>This document defines the bylaws under which the Apache CouchDB project operates. It defines the <a href="#roles">roles and responsibilities</a> within the project, who may vote, how <a href="#voting">voting</a> works, how conflicts are resolved, and voting rules for specific <a href="#types">decision types</a>.
+<p>This document defines the bylaws under which the Apache CouchDB project operates. It describes the <a href="#roles">roles and responsibilities</a> within the project, who may vote, how <a href="#voting">voting</a> works, how to resolve conflicts, and specifies voting rules for specific <a href="#types">decision types</a>.
 
-<p>This document is written for anyone who wishes to participate in the project. <strong>If this is your first time through this document, read this introduction, then read all the bolded text for a summary of the bylaws.</strong> Then, as you need more detail, read past the bolded text for an expanded explanation.
+<p>This document is for anyone who wishes to participate in the project. <strong>If this is your first time through this document, read this introduction, then read all the bolded text for a summary of the bylaws.</strong> Then, as you want, read past the bolded text for an expanded explanation.
 
-<p>CouchDB is a project of the <em>Apache Software Foundation</em> (ASF). Apache CouchDB, CouchDB, and the CouchDB logo are trademarks of the ASF. The project resources are licensed to the public under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>. Releases are made in the form of official signed source code archives. The <a href="https://www.apache.org/foundation/faq.html">ASF FAQ</a> explains the operation and background of the Foundation.
+<p>CouchDB is a project of the <em>Apache Software Foundation</em> (ASF). Apache CouchDB, CouchDB, and the CouchDB logo are trademarks of the ASF. We license the project resources to the public under the <a href="http://www.apache.org/licenses/LICENSE-2.0.html">Apache License 2.0</a>. We make releases in the form of officially signed source code archives. The <a href="https://www.apache.org/foundation/faq.html">ASF FAQ</a> explains the operation and background of the foundation.
 
-<p>CouchDB operates under a set of common principles known collectively as <a href="https://www.apache.org/foundation/how-it-works.html">the Apache Way</a>:
+<p>CouchDB operates under a set of shared principles known collectively as <a href="https://www.apache.org/foundation/how-it-works.html"><em>the Apache Way</em></a>:
 
   <ul>
     <li>Collaborative software development
     <li>Commercial-friendly standard license
-    <li>Consistently high quality software
+    <li>Consistently high-quality software
     <li>Respectful, honest, technical-based interaction
     <li>Faithful implementation of standards
     <li>Security as a mandatory feature
   </ul>
 
-<p>We value the community more than the code. A strong and healthy community should be a fun and rewarding place for everyone involved. Code, and everything else that goes with that code, will be produced by a healthy community over time.
+<p>We value the community more than the code. A healthy community should be a fun and rewarding place for everyone involved. A healthy community will produce written code (and everything else) over time. The same is not true in reverse.
 
-<p>The direction of the project and the decisions we make are up to you. If you are participating on <a href="https://couchdb.apache.org/#mailing-lists">the mailing lists</a> you have the right to make decisions. All decisions about the project are taken on the mailing lists. There are no lead developers, nor is there any one person in charge.
+<p>The direction of the project and the decisions we make are up to you. If you are participating on <a href="https://couchdb.apache.org/#mailing-lists">the mailing lists</a>, you have the right to make decisions. We make all decisions about the project on the mailing lists. There are no lead developers, nor is there any one person in charge.
 
-<p>Anyone can subscribe to the public mailing lists, and in fact, you are encouraged to do so. The development mailing list is not just for developers, for instance. It is for anyone who is interested in the development of the project. Everybody's voice is welcome.
+<p>Anyone can subscribe to the public mailing lists, and in fact, you are encouraged to do so. The development mailing list is not just for developers, for instance. It is for anyone interested in the development of the project. Everybody's voice is welcome.
 
-<p>Finally, use of these bylaws to enforce the letter of any rule and not its spirit (also known as "<a href="https://en.wikipedia.org/wiki/Rules_lawyer">rule lawyering</a>") is not acceptable behaviour.
+<p>Finally, the use of these bylaws to enforce the letter of any rule and not its spirit (also known as "<a href="https://en.wikipedia.org/wiki/Rules_lawyer">rule lawyering</a>") is not acceptable behavior.
 
-<h2 id="roles">2. Roles and Responsibilities</h2>
+<h2 id="roles">2. Roles and responsibilities</h2>
 
-<p><strong>The ASF <a href="https://www.apache.org/foundation/how-it-works.html#roles">defines a set of roles</a> with associated rights and responsibilities. These roles govern what tasks an individual may perform within the project. The roles are defined in the following sections.</strong>
+<p><strong>The ASF <a href="https://www.apache.org/foundation/how-it-works.html#roles">defines a set of roles</a> with associated rights and responsibilities. These roles govern what tasks an individual may perform within the project. The roles are described in the following sections.</strong>
 
-<p>Your role is bestowed on you by your peers in recognition of your past contributions to the project and your position of trust within the community. It is not tied to your job, your current employer, or your current activity level. We are interested in you as an individual and we understand that your interactions with the project may change over time.
+<p>Your role is bestowed on you by your peers in recognition of your past contributions to the project and your position of trust within the community. It is not tied to your job, your current employer, or your current activity level. We are interested in you as an individual, and we understand that your interactions with the project may change over time.
 
-<p>Roles are never rescinded because of inactivity, unless that inactivity is causing a problem for the project. Fortunately, our decision making process means that inactivity is very rarely a problem. Roles will be rescinded if the <a href="#pmc">Project Management Committee</a> (or <a href="#pmc">PMC</a>, see 2.4. below) believes the individual is no longer able to responsibly discharge the duty of the role.
+<p>Roles are never rescinded because of inactivity—unless that inactivity is causing a problem for the project. Fortunately, our decision-making process means that inactivity is very rarely a problem. Roles will be rescinded if the <a href="#pmc">Project Management Committee</a> (or <a href="#pmc">PMC</a>, see 2.4. below) believes the individual is no longer able to discharge the duty of the role responsibly.
 
-<p>We understand that you have many roles in life. We use a hat metaphor to talk about these roles. For instance, you might have your work hat as well as several ASF hats. We expect you to know when to wear the appropriate hat, and to comport yourself in a manner befitting the interests of the Foundation when interacting with the project. Failure to do this is a serious dereliction of duty.
+<p>We understand that you have many roles in life. We use a hat metaphor to talk about these roles. For instance, you might have your work hat as well as several ASF hats. We expect you to know when to wear the appropriate hat, and to comport yourself in a manner befitting the interests of the foundation when interacting with the project. Failure to do this is considered a severe dereliction of duty.
 
-<p>Sometimes it is a good idea to tell people which hat you are wearing. For instance, the PMC Chair might start an informal email by stating they are not wearing the PMC Chair's hat, just to be clear about how the statements ought to be interpreted.
+<p>Sometimes it is a good idea to tell people which hat you are wearing. For instance, the PMC chair might start an informal email by explicitly stating that they are not wearing the PMC chair's hat. Doing so can help to clear up the meaning (and implication) of what is said.
 
-<p>We expect you to act in good faith. This is very important for a community that depends so heavily on trust.
+<p>We expect you to act in good faith. Doing so is very important for a community that depends so heavily on trust.
 
 <h3 id="users">2.1. Users</h3>
 
-<p><strong>The most important participants in the project are people who use our software.</strong>
+<p><strong>The most critical participants in the project are people who use our software.</strong>
 
-<p>Users can participate by talking about the project, providing feedback, and helping others. This can be done at the ASF or elsewhere, and includes being active on <a href="https://lists.apache.org/list.html?user@couchdb.apache.org">the user mailing list</a>, third-party support forums, blogs, and social media. Users who participate in this way automatically become contributors.
+<p>Users can participate by talking about the project, providing feedback, and helping others. Participation can be done at the ASF or elsewhere and includes being active on the user mailing list, third-party support forums, blogs, and social media. Users who participate in this way become contributors automatically.
 
-  <h3 id="contributors">2.2. Contributors</h3>
+<h3 id="contributors">2.2. Contributors</h3>
 
 <p><strong>A contributor is someone who makes contributions to the community, project, documentation, or code.</strong>
 
-<p>There is no special requirement to become a contributor. If you have a great idea for the project, you can get to work immediately. There is no need to ask permission. Most things can be accomplished by contributors with no special privileges or status on the project. Assistance can be provided if you need access to project resources to get your work done.
+<p>There is no special requirement to become a contributor. If you have a good idea for the project, you can get to work immediately. There is no need to ask permission. Contributors can accomplish most things with no special privileges or status on the project. We will assist you if you need access to project resources to get your work done.
 
 <p>A contributor who makes sustained contributions to the project may be invited to become a committer.
 
 <h3 id="committers">2.3. Committers</h3>
 
-<p><strong>A committer is someone who is committed to the project. In return for their commitment, they are given a binding vote in certain project decisions. Committers are hence responsible for the ongoing health of the project and the community.</strong>
+<p><strong>A committer is someone who is committed to the project. In return for your commitment, we give you a binding vote in some specific types of project decision. Committers are hence responsible for the ongoing health of the project and the community.</strong>
 
-<p>We recognise commitment in many different areas. These include, but are not limited to:
+<p>We recognize commitment in many different areas. These include, but are not limited to:
 
   <ul>
-    <li>Community (community management, ticket triage, helping new users, events etc.)
-    <li>Project (blogging, marketing, design, UX, branding, etc)
-    <li>Documentation (documentation, localisation/internationalisation, etc.)
-    <li>Code (new features, bug fixing, quality assurance, release management etc.)
+    <li>Community (e.g., community management, ticket triage, helping new users, and helping with events)
+    <li>Project (e.g., blogging, marketing, design, UX, and branding)
+    <li>Documentation (e.g., documentation, localisation, and internationalisation)
+    <li>Code (e.g., new features, bug fixing, quality assurance, and release management)
   </ul>
 
 <p>More details are available in <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Contributor+Guide">the contributor guide</a>. If any of these things sound interesting to you, we welcome your help.
 
-<p>The role of committer is mandated at the Foundation level. Unfortunately, the usual definition of that word—being someone who commits code—can mean that non-coders are never given binding votes on a project. We think that's a problem. Contributions come in many shapes and sizes. Indeed, many of those non-code contributions are what the project needs the most.
+<p>The ASF mandates the role of committer. Unfortunately, the usual definition of that word—being someone who commits code—can mean that projects fail to give binding votes to non-coders. We think that's a problem. Contributions come in many shapes and sizes. Indeed, many of those non-code contributions are what the project needs the most.
 
-<p>To make this clear, we have chosen to define a committer as someone who is <em>committed</em>. We mean this in the sense of being loyal to the project and its interests. It is a position of trust, not an expectation of activity level. Anyone who is supportive of the community and the project will be considered as a candidate for being a committer.
+<p>To make this clear, we have chosen to define a committer as someone who is <em>committed</em>. We mean this in the sense of being loyal to the project and its interests. It is a position of trust, not an expectation of activity level. We will consider anyone supportive of the community and the project for the role of committer.
 
-<p>As a matter of convenience, committers are also given write access to all of the public project infrastructure, including source control repositories, website, issue tracker, wiki, and blog. Access to social media accounts, and other third-party services, will be granted upon request.
+<p>As a matter of convenience, we also give committers write access to all of the public project infrastructure, including source control repositories, website, issue tracker, wiki, and blog. We will grant access to social media accounts and other third-party services on request.
 
-<p>All committers are required to have a signed <em>Individual Contributor License Agreement</em> (ICLA) on file. There is an <a href="http://www.apache.org/dev/committers.html">ASF FAQ</a> which provides more details about the requirements at the Foundation level.
+<p>All committers are required to have a signed <em>Individual Contributor License Agreement</em> (ICLA) on file. There is an <a href="http://www.apache.org/dev/committers.html">ASF FAQ</a> which provides more details about the requirements at the foundation-level.
 
-<p>Committers are expected to work cooperatively and to have good social skills. This is more important than any other sort of skill. Our committers make up the bulk of our active community, and as such, we rely on them to help us build and maintain that community.
+<p>Committers are expected to work cooperatively and have good social skills. Social skills are more important than any other sort of skill. Our committers make up the bulk of our active community, and as such, we rely on them to help us build and maintain that community.
 
 <p>A committer who makes a sustained contribution to the project may be invited to become a <em>Project Management Committee</em> (PMC) member.
 
@@ -101,9 +101,9 @@
 
 <p><strong>The <em>Project Management Committee</em> (PMC) is responsible for the management of the project.</strong>
 
-<p>At the most basic level, the role of the PMC is oversight. The PMC must ensure that all relevant bylaws , policies, and procedures  are adhered to. These exist at the Foundation-level and the project-level. See the <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Project+affairs">project affairs</a> page for more information.
+<p>At the most basic level, the role of the PMC is to provide oversight. The PMC must ensure that the project adheres to all the relevant bylaws, policies, and procedures. These exist at the foundation-level and the project-level. See the <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Project+affairs">project affairs</a> page for more information.
 
-<p>Beyond this requirement, the primary goal of the PMC is to invest in the long term wellbeing of the community. For this reason, one of the most basic tasks of the PMC is the recruitment and management of project contributors. We believe that the size, diversity, and health of the community is essential for the quality, stability, and robustness of project and its social structures.
+<p>Additionally, the PMC must invest in the long term wellbeing of the community. For this reason, one of the most basic tasks the PMC should undertake is the recruitment and management of project contributors. We believe that the size, diversity, and health of the community is essential for the quality, stability, and robustness of the project and its social structures.
 
 <p>Activities of the PMC include, but are not limited to:
 
@@ -117,31 +117,31 @@
     <li>Press and analyst relations
   </ul>
 
-<p>PMC members are held to a much higher standard than regular community members. This includes strict hat wearing, equitable decision making, and exemplary conduct. People look to PMC members for cues about how to behave. It is important that all PMC members understand the responsibility that they bear, and that they are individually committed to improving themselves and the project.
+<p>We hold PMC members to a much higher standard than regular community members. For example, strict hat wearing, equitable decision making, and exemplary conduct. People look to PMC members for cues about how to behave. It is essential that all PMC members understand the responsibility they bear are individually committed to improving themselves and the project.
 
 <p>While security issues and release management are the responsibility of the PMC, the PMC typically delegates this to committers.
 
 <h3 id="chair">2.5. Chair</h3>
 
-<p><strong>The project Chair is a PMC member responsible for Foundation level administrative tasks.</strong> It is not a technical leadership position, meaning the Chair has no special say in ordinary project decisions. But we do think of it as a cultural leadership position. Accordingly, position on cultural issues is something to consider when electing a Chair.
+<p><strong>The project chair is a PMC member responsible for foundation-level administrative tasks.</strong> It is not a technical leadership position, meaning the chair has no special say in ordinary project decisions. However, we do think of it as a cultural leadership position. Accordingly, position on cultural issues is something to consider when electing a chair.
 
-<p>The Chair is elected by the PMC but appointed by the ASF Board via a Board resolution. The Chair is an officer of the Apache Software Foundation (with an official title of <em>Vice President, Apache CouchDB</em>) and has primary responsibility to the Board for the management of the project. The Chair is the eyes and ears of the Board, and reports quarterly on developments within the project.
+<p>The PMC elect the chair, but the board must officially appoint them with a board resolution. The chair is an officer of the ASF (with an official title of <em>Vice President, Apache CouchDB</em>) and has a primary responsibility to the board for the management of the project. The chair is the eyes and ears of the board, and reports quarterly on developments within the project.
 
-<p>Remember that, as in any meeting, the Chair is a facilitator and their role within the PMC is to ensure that everyone has a chance to be heard and to enable meetings to flow smoothly.
+<p>The chair is a facilitator, and their role within the PMC is to ensure that everyone has a chance to be heard and to enable meetings to flow smoothly.
 
-<p>If the current Chair resigns, or the term of the Chair expires, the PMC will hold a Chair election.
+<p>If the current chair resigns, or the term of the chair expires, the PMC will hold a chair election.
 
-<p>The Chair has a 12 month term. The intention of this term is to allow for a rotation of the role amongst the PMC members. This does not prohibit the PMC from selecting the same Chair to serve consecutive terms.
+<p>The chair has a 12-month term. The allows for a rotation of the role amongst the PMC members. However, the PMC may select the same chair to serve consecutive terms.
 
 <h3 id="board">2.6. Board of Directors</h3>
 
-<p><strong>The Chair is responsible for the project to the Board of Directors (the Board) of the ASF.</strong> The Board is the nine-person legal governing body of the ASF, elected by the <a href="http://apache.org/foundation/members.html">members</a> of the Foundation. The Board provides the oversight of the Foundation's activities and operation, and has the responsibility of applying and enforcing the <a href="http://apache.org/foundation/bylaws.html">ASF's bylaws</a>.
+<p><strong>The chair is responsible for the project to the Board of Directors (the board) of the ASF.</strong> The board is the nine-person legal governing body of the ASF, elected by the <a href="http://apache.org/foundation/members.html">members</a> of the foundation. The board provides the oversight for the foundation and has the responsibility of upholding the <a href="http://apache.org/foundation/bylaws.html">ASF's bylaws</a>.
 
-<h2 id="decisions">3. Decision Making</h2>
+<h2 id="decisions">3. Decision making</h2>
 
 <p>This section explains our approach to decision making and the formal structures we have in place to make this as easy as possible.
 
-<p><strong>In descending order of preference, we prefer that decisions are made via:</strong>
+<p><strong>In descending order of preference, we prefer to make decisions via:</strong>
 
   <ul>
     <li><strong><a href="#lazy">Lazy consensus</a> or <a href="#rtc">RTC</a></strong>
@@ -151,15 +151,15 @@
 
 <p>Our goal is to build a community of trust, reduce mailing list traffic, and deal with disagreements swiftly when they occur.
 
-<p>All decision making must happen on <a href="https://couchdb.apache.org/#mailing-lists">the mailing lists</a>. Any discussion that takes place away from the lists (for example on IRC or in person) must be brought to the lists before anything can be decided. We have a saying: if it's not on the lists, it didn't happen. We take this approach so that the greatest amount of people have a chance to participate.
+<p>All decision making must happen on <a href="https://couchdb.apache.org/#mailing-lists">the mailing lists</a>. You must bring any discussion that takes place away from the lists (e .g., on IRC or in person) back to the lists before making any decisions. We have a saying: "if it's not on the lists, it didn't happen." We take this approach so that the most amount of people have a chance to participate.
 
-<p>Decisions should be made on the mailing list associated with the decision. For example, marketing decisions happen on <a href="https://lists.apache.org/list.html?marketing@couchdb.apache.org">the marketing list</a>. By default, anything without a specific list should be done in public on the main development list. Anything that needs to be private will be done on the private list.
+<p>Please try to make decisions on the mailing list most appropriate for the decision. For example, marketing decisions should happen on <a href="https://lists.apache.org/list.html?marketing@couchdb.apache.org">the marketing list</a>. If no specific list exists for the type of decision you want to make, take it to the main development list. If it's a private matter, take it to the private list.
 
-<p>Our decision making processes are designed to reduce blockages. It is understood that people come and go as time permits. It is not practical to hear from everybody on every decision. Sometimes, this means a decision will be taken while you are away from the project. It is reasonable to bring such decisions up for discussion again, but this should be kept to a minimum.
+<p>Our decision-making processes are designed to reduce blockages. We understood that people come and go as time permits. It is not practical to hear from everybody on every decision. Sometimes, this means we will decide something while you are away from the project. You may bring up decisions up for re-discussion if you want—but please try to keep this to a minimum.
 
-<h3 id="lazy">3.1. Lazy Consensus</h3>
+<h3 id="lazy">3.1. Lazy consensus</h3>
 
-<p><strong>When you are convinced that you know what the community would like to see happen, you can assume that you already have permission and get on with the work. We call this <a href="http://www.apache.org/foundation/glossary.html#LazyConsensus">lazy consensus</a>.</strong> You don't have to insist that people discuss or approve your plan, and you certainly don't need to call a vote. Just assume your plan is okay unless someone says otherwise. This applies to anything in the list of <a href="#types">decision types</a> in section 3.6. where lazy consensus is allowed.
+<p><strong>When you feel convinced you know what the community would like to see happen, you can assume that you already have permission and get on with the work. We call this <a href="http://www.apache.org/foundation/glossary.html#LazyConsensus">lazy consensus</a>.</strong> You don't have to insist that people discuss or approve your plan, and you certainly don't need to call a vote. Just assume your plan is okay unless someone says otherwise. This principle applies to anything in the list of <a href="#types">decision types</a> in section 3.6 that allows lazy consensus.
 
   <blockquote>
     "It's easier to ask forgiveness than it is to get permission." — Grace Hopper
@@ -174,33 +174,33 @@
     <li>It cuts down on the amount of unnecessary discussion
   </ol>
 
-<p>For this to work properly, active committers are expected to be paying attention to the project. Objecting a long time after a change has been made may require large amounts of additional work to be thrown away or redone.
+<p>For this to work, active committers are expected to be paying attention to the project. Objecting a long time after the project has made a change may require large amounts of additional work to be thrown away or redone.
 
 <p>Sometimes, you might not be sure what the community would want. If this is the case, you can post a note to the appropriate <a href="https://couchdb.apache.org/#mailing-lists">mailing list</a> with an outline of what you intend to do. If nobody objects after 72 hours, you can safely assume consensus and proceed with your plan.
 
-<p>An important side effect of this policy is that <em>silence is assent</em>. There is no need for discussion, and no need for agreement to be voiced. If you make a proposal to the list and nobody responds, that should be interpreted as implicit support for your idea, and not a lack of interest. This can be hard to get used to, but is an important part of how we do things.
+<p>A corollary of this policy is that <em>silence is assent</em>. There is no need for discussion and no need for any agreement to be voiced. If you propose something to the list and nobody responds, you can interpret that as implicit support for your idea, and not a lack of interest. This principle can be hard to get used to—but it is an essential ingredient of how we operate.
 
 <h3 id="discussion">3.2. Discussion</h3>
 
-<p><strong>If lazy consensus fails (i.e. someone objects) you can start a discussion or you can abandon the proposal.</strong>
+<p><strong>If lazy consensus fails (i.e., someone objects) you can start a conversation, or you can abandon the proposal.</strong>
 
 <p>Please try to be respectful of people's time and attention. It is a non-renewable resource and the only thing we always need more of.
 
-<p>Proposals should be explained clearly and come with adequate justification. Disagreements should be constructive and ideally come with alternative proposals. The goal is to reach a positive outcome for the project, not convince others of your opinion.
+<p>Proposals should be explained clearly and come with adequate justification. Disagreements should be constructive and ideally come with alternative suggestions. The goal is to reach a positive outcome for the project, not convince others of your opinion.
 
-<p>If a proposal is particularly controversial, try making it reversible. Reframe the proposal as an experiment (either at the project level or the feature level) and identify a timeline for evaluation along with unambiguous success and failure criteria. These sorts of proposal are usually much easier to agree on.
+<p>If a proposal is particularly controversial, try making it reversible. Reframe the proposition as an experiment (either at the project level or the feature level) and identify a timeline for evaluation along with unambiguous success and failure criteria. These sorts of proposals are usually much easier to agree on.
 
 <p>If a clear consensus emerges, you can proceed without a vote. Otherwise, you should abandon the proposal or move to a vote.
 
-<p>Voting is a failure mode of discussion. But that doesn't mean you should avoid it. It is a very powerful tool that should be used to terminate a seemingly interminable discussion. Knowing when to end a discussion and call a vote is one of the most useful skills a contributor can master.
+<p>Voting is a failure mode of discussion. However, that doesn't mean you should avoid it. Voting is a potent tool that should be used to terminate a seemingly interminable debate. Knowing when to end a discussion and call a vote is one of the most useful skills a contributor can master.
 
 <h3 id="voting">3.3. Voting</h3>
 
 <p><strong><a href="https://www.apache.org/foundation/voting.html">Votes</a> are used to indicate approval or disapproval of something.</strong>
 
-<p>We do this by replying with a signed number, usually +1 or -1. Occasionally people choose to vote with larger amounts (eg. +1000) to indicate strong feelings, or in fractional amounts (eg. -0.5) to convey support or disagreement without the full weight of a +1 or -1 vote. For the purpose of tallying, all values will be counted as +1, -1, or nothing.
+<p>We do this by replying with a signed number, usually +1 or -1. Occasionally people choose to vote with larger values (e.g., +1000) to indicate strong feelings, or in fractional values (e.g., -0.5) to convey support or disagreement without the full weight of a +1 or -1 vote. For the purpose of tallying, we count all values as +1, -1, or nothing.
 
-<p>Here are some example votes, with what they mean, and how they will be counted in the final vote tally:</p>
+<p>Here are some example votes, with what they mean, and how we would count them in the final vote tally:</p>
 
   <table>
     <tr>
@@ -250,15 +250,15 @@
     </tr>
   </table>
 
-<p>There are three types of voting: informal, formal, and vetos. An informal vote is a quick way to get people's feelings on something. A formal vote, on the other hand, requires an approval model and a <a href="#decisions">decision type</a>. More detail on <a href="#approval">approval models</a>, <a href="#rtc">RTC and technical vetos</a>, <a href="#rfc">RFCs</a>, <a href="#api">API changes and deprecations</a> and <a href="#types">decision types</a> is available in the following sections.
+<p>There are three types of voting: informal, formal, and vetos. An informal vote is a quick way to get people's feelings about something. A formal vote, on the other hand, requires an approval model and a <a href="#decisions">decision type</a>. More detail on <a href="#approval">approval models</a>, <a href="#rtc">RTC and technical vetos</a>, <a href="#rfc">RFCs</a>, <a href="#api">API changes and deprecations</a>, and <a href="#types">decision types</a> is available in the following sections.
 
-<p>All formal voting must be done in an email thread with the appropriate <a href="#tags">subject tag</a>. Formal votes may contain multiple items for approval and these should be clearly separated. Formal voting is then carried out by replying to the vote mail. Formal votes are open for a period of at least 72 hours to allow all active voters time to consider the vote. Votes can be held open longer than this at the discretion of the person who initiated the vote.
+<p>You must conduct all formal voting in an email thread with the appropriate <a href="#tags">subject tag</a>. Formal votes may contain multiple items for approval, and these should be separated clearly. Formal voting is then carried out by replying to the vote mail. Formal votes are open for a period of at least 72 hours to allow all active voters time to consider the vote. Votes can be held open longer than this at the discretion of the person who initiated the vote.
 
-<p>Votes on <a href="#types">PMC decisions</a> are binding if they are cast by a PMC member. For all other purposes, votes are binding if they are cast by a committer. However, it is important to remember that all participants on a list get a vote. And you are encouraged to vote, even if your vote is not binding. This is a good way to get involved in the project and helps to inform the decision-making process.
+<p>Votes on <a href="#types">PMC decisions</a> are binding if a PMC member casts them. For all other purposes, votes are binding if a committer casts them. However, it is essential to remember that all participants on a list get a vote. Moreover, you are encouraged to vote, even if your vote is not binding. Voting is an excellent way to get involved in the project and helps to inform the decision-making process.
 
-<p>You are encouraged to use an informal voting model to take a quick poll or to wrap up a discussion, whether you are a committer yet or not. These votes are informal and can be initiated by anyone. Binding votes are only needed for project-level decision-making.
+<p>You are encouraged to use an informal voting model to take a quick poll or to wrap up a discussion, whether you are a committer yet or not. Anyone can initiate these votes.
 
-<h3 id="approval">3.4. Approval Models</h3>
+<h3 id="approval">3.4. Approval models</h3>
 
 <p><strong>We use three different approval models for formal voting</strong>:
 
@@ -277,53 +277,53 @@
       </ul>
   </ul>
 
-<p>RTC is only ever used in the context of a code review or a pull request, and does not require a separate vote thread. Each of the other approval models requires a vote thread.
+<p>RTC is only ever used in the context of a code review or a pull request and does not require a separate vote thread. Each of the other approval models requires a vote thread.
 
-<p>A -1 vote is never called a veto except when using the RTC approval model. This is because a single -1 vote never has the power to block a vote outside of RTC.
+<p>A -1 vote is never called a veto except when using the RTC approval model because a single -1 vote never has the power to block a vote outside of RTC.
 
-<p>Which approval model to use is dictated by the table in section 3.6. This is project policy, and can be changed by amending this document.
+<p>Which approval model to use is dictated by the table in section 3.6.
 
-<p>For electing a new Chair, the PMC may opt to use <em>Single Transferable Vote</em> (STV) which comes with its own rules. <a href="http://steve.apache.org/">Apache STeVe</a> was specifically designed to enable this process.
+<p>For electing a new chair, the PMC may opt to use <em>Single Transferable Vote</em> (STV) which comes with its own rules. You can use <a href="http://steve.apache.org/">Apache STeVe</a> for STF votes.
 
-<h3 id="rtc">3.5. Review-Then-Commit and Technical Vetos</h3>
+<h3 id="rtc">3.5. Review-then-commit and technical vetos</h3>
 
-<p>Typically, CouchDB uses the <a href="http://www.apache.org/foundation/glossary.html#ReviewThenCommit">Review-Then-Commit</a> (<em>RTC</em>) model of code collaboration. RTC allows work to proceed on separate feature or bugfix branches, and requires at least one other developer to review and approve the changes before they are committed to a release branch. A release branch is any branch that a release might be prepared from, such as <code>master</code>, <code>1.6.x</code>, and so on. Notifications of these changes are sent to <a href="https://lists.apache.org/list.html?commits@couchdb.apache.org">the commits mailing list</a>, with GitHub discussion appearing on <a href="https://lists.apache.org/list.html?notifications@couchdb.apache.org">the notifications mailing list</a>. It is expected that the rest of the community is regularly reviewing these changes.
+<p>Typically, CouchDB uses the <a href="http://www.apache.org/foundation/glossary.html#ReviewThenCommit">Review-Then-Commit</a> (<em>RTC</em>) model of code collaboration. RTC allows work to proceed on non-release branches and requires at least one other developer to review and approve the changes before they are committed to a release branch. A release branch is any branch the project can use to prepare a release, such as <code>master</code> or <code>1.6.x</code>. Notifications of these changes are sent to <a href="https://lists.apache.org/list.html?commits@couchdb.apache.org">the commits mailing list</a>, with GitHub discussion appearing on <a href="https://lists.apache.org/list.html?notifications@couchdb.apache.org">the notifications mailing list</a>. We expect the community to review these changes regularly.
 
-<p><strong>Any change made to a release branch or to the <code>master</code> branch is a <em>technical decision</em> of the project. If a committer wants to object to a technical decision, they have the option of casting a -1 vote. We call this a veto.</strong> Vetos can only be made for technical reasons. A -1 vote is not considered a veto in any other context. Vetos should be used sparingly, and only after careful consideration.
+<p><strong>Any change made to a release branch or the <code>master</code> branch is a <em>technical decision</em> of the project. If a committer wants to object to a technical decision, they have the option of casting a -1 vote. We call this a veto.</strong> You can only veto for technical reasons. A -1 vote is not considered a veto in any other context. Vetos should be used sparingly, and only after careful consideration.
 
-<p>All vetoes must be justified and vetoes without justification are null and void. The validity of the justification can be challenged and the outcome is decided with a vote. If the justification is valid, a veto cannot be overruled and stands until withdrawn by the caster. If you disagree with a veto, you must lobby the person casting the veto to withdraw their veto. If a veto is not withdrawn, the commit must be reverted in a timely manner.
+<p>All vetoes must be justified, and vetoes without justification are null and void. You can challenge the validity of a veto justification, and the project will decide the outcome with a vote. If the justification is valid, a veto cannot be overruled and stands until withdrawn by the caster. If you disagree with a veto, you must lobby the person casting the veto to withdraw their veto. If the caster does not withdraw their veto, the offending commit must be promptly reverted.
 
 <p>Here's how a veto might lead to a code revert:
 
   <ul>
-    <li>Alice commits a change
-    <li>Bob spots the change and realises that it's going to cause a major problem
-    <li>Bob replies to the commit email with a -1 vote and a justification
+    <li>Abe commits a change
+    <li>Beth spots the change and realizes that it's going to cause a major problem
+    <li>Beth replies to the commit email with a -1 vote and a justification
     <li>A discussion ensues, leading to consensus
-    <li>Alice reverts the change
+    <li>Abe reverts the change
   </ul>
 
-<p>If the discussion did not reach consensus, Alice could challenge the validity of Bob's justification. At that point, the PMC would vote on the issue. If the PMC found that the justification was valid, Alice would have to revert the change or petition Bob to withdraw the veto. If the PMC found the justification invalid, the veto is null and void.
+<p>If the parties do not reach an agreement, Abe could challenge the validity of Beth's justification. At that point, the PMC would vote on the issue. If the PMC found that the justification was valid, Abe would have to revert the change or petition Beth to withdraw the veto. If the PMC found the justification invalid, the veto is null and void.
 
 <h3 id="rfc">3.6 Request For Comment (RFC) process</h3>
 
-<p>For major changes to the fuctionality of CouchDB, a Request For Comment (RFC) process has been established. The intent of an RFC is to ensure sufficient public discussion has occurred on the design of new features, that the proposal is adequately captured in a summary document, and that there is community acceptance of the proposal. The completed RFC template for the proposal then becomes the basis for the new functionality's documentation.</p>
+<p>We have established a Request For Comment (RFC) process for major changes to the functionality of CouchDB. An RFC intends to ensure sufficient discussion has occurred, that the proposal is adequately captured in a summary document, and that there is community acceptance of the plan. The completed RFC template then becomes the basis for the new functionality's documentation.</p>
 
 <p>The process is:</p>
 
   <ul>
     <li>Start a [DISCUSS] thread on <a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">the developer mailing list</a>. Discuss your proposal in detail, including which modules/applications are affected, any HTTP API additions and deprecations, and security issues.</li>
-    <li>When there is consensus on the approach from the community, <a href="https://s.apache.org/CouchDB-RFC">complete the RFC template</a> and work through any final revisions to the document, with the support of the developer mailing list.</li>
-    <li>Start the RFC <strong>vote</strong> on the developer mailing list. Hold the vote according to the <em>lazy majority process</em>: at least 3 +1 votes, and more binding +1 than binding -1 votes.</li>
+    <li>When there is consensus on the approach, <a href="https://s.apache.org/CouchDB-RFC">complete the RFC template</a>, and work through any final revisions to the document with the support of the developer mailing list.</li>
+    <li>Start the RFC <strong>vote</strong> on the developer mailing list. Hold the vote according to the <em>lazy majority process</em>: at least 3 +1 votes, and more binding +1 votes than binding -1 votes.</li>
   </ul>
 
 <h3 id="api">3.7 API changes and deprecations</h3>
 
-<p>Whenever a change is proposed to a release branch or <code>master</code> that removes or changes an existing HTTP API endpoint in a way that breaks backwards compatibility with a released version of CouchDB, the proposed change <strong><em>must</em> be announced on <a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">the developer mailing list</a>, and a minimum of a <a href="#lazy">lazy consensus</a> decision is required.</strong>
+<p>Before you make a change to a release branch that removes or changes an existing HTTP API endpoint in a way that breaks backward compatibility with a released version of CouchDB,  you <em>must</em> propose the change on the <a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">developer mailing list</a>. A minimum of a <a href="#lazy">lazy consensus</a> is required to proceed.</strong>
 
-<p>This policy is not intended to preserve bugs in HTTP API endpoints across released versions of CouchDB in perpetuity, nor shall it be used to assert consistency of undocumented, implementation-specific behaviour across major releases. Additions of new endpoints that fall short of the need for an RFC, or changes that do not affect backwards compatibility, do not require this notification and process, but announcement to the developer mailing list is still strongly encouraged.</p>
+<p>This policy is not intended to preserve bugs in HTTP API endpoints across released versions of CouchDB in perpetuity, nor shall it be used to assert consistency of undocumented, implementation-specific behavior across major releases. The addition of new endpoints that fall short of the need for an RFC, or changes that do not affect backward compatibility, do not require that you go through this process. However, proposing the change is still strongly encouraged.</p>
 
-<h3 id="types">3.8. Decision Types</h3>
+<h3 id="types">3.8. Decision types</h3>
 
 <p><strong>This section describes the various decision types and the rules that apply to them.</strong></p>
 
@@ -361,10 +361,10 @@
     <tr>
       <td>Non-technical decision
       <td>
-	A non-technical decision is any other sort of change, or any sort of decision that falls outside of the other decision types. It is a catch-all decision type.
+	A non-technical decision is any other sort of change or decision that falls outside of the other decision types. It is a catch-all decision type.
 	<br>
 	<br>
-	Non-technical decisions should normally be made with lazy consensus, or by the entire community using discussion-led consensus-building, and not through formal voting.
+	It is preferable that you make non-technical decisions via lazy consensus or discussion-led consensus-building.
       <td>Whichever mailing list is most appropriate
       <td>Allowed
       <td>Lazy majority
@@ -378,7 +378,7 @@
 	Challenge the validity of a veto.
 	<br>
 	<br>
-	A veto is only valid when it is justified with a sound technical argument.
+	A veto is only valid when the caster has justified it with a sound technical argument.
       <td><a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">Main development list</a>
       <td>No
       <td>Lazy 2/3 majority
@@ -392,7 +392,7 @@
 	Make an official release.
 	<br>
 	<br>
-	Release candidates can be prepared by anyone.
+	Anyone can prepare release candidates.
       <td><a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">Main development list</a>
       <td>No
       <td>Lazy majority
@@ -406,7 +406,7 @@
 	Elect a new committer.
 	<br>
 	<br>
-	Nominations can be made by anyone by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
+	Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy majority
@@ -420,7 +420,7 @@
 	Elect a new PMC member.
 	<br>
 	<br>
-	Nominations can be made by anyone by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
+	Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy 2/3 majority
@@ -429,8 +429,8 @@
       <td>No
     </tr>
     <tr>
-      <td>Elect Chair
-      <td>Elect a new Chair.
+      <td>Elect chair
+      <td>Elect a new chair.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy 2/3 majority or STV
@@ -460,7 +460,7 @@
     </tr>
     <tr>
       <td>Chair removal
-      <td>Remove the Chair.
+      <td>Remove the chair.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy 2/3 majority
@@ -480,9 +480,9 @@
     </tr>
   </table>
 
-<h2 id="other">4. Other Topics</h2>
+<h2 id="other">4. Other topics</h2>
 
-<h3 id="tags">4.1. Subject Tags</h3>
+<h3 id="tags">4.1. Subject tags</h3>
 
 <p><strong>A subject tag is a string like "[TAG]" that appears at the start of an email subject. We use these to communicate the type of message being sent.</strong>
 
@@ -492,7 +492,7 @@
     <code>[VOTE] [REVISED] Official CouchDB bylaws</code>
   </blockquote>
 
-<p>If a VOTE or PROPOSAL thread is started without the requisite tag, its validity can be challenged. Every other tag is optional.
+<p>If a VOTE or PROPOSAL thread is started without the requisite tag, you can challenge its validity. Every other tag is optional.
 
 <p>We have agreed on the following tags, but you are free to coin your own.</p>
 
@@ -500,7 +500,7 @@
     <tr>
       <th>Subject tag
       <th>Description
-      <th>Decision making
+      <th>Decision-making
       <th>Timeframe
     </tr>
     <tr>
@@ -511,7 +511,7 @@
     </tr>
     <tr>
       <td>REQUEST
-      <td>This is a request for some action to be taken (prepare release notes, testing, merge, etc)
+      <td>This is a request for some action to be taken (e.g., prepare release notes, test something, or merge a pull request)
       <td>No
       <td>NA
     </tr>
@@ -529,7 +529,7 @@
     </tr>
     <tr>
       <td>NOTICE
-      <td>This is a notice of action taken, or action about to be taken (i.e. no discussion or consensus needed)
+      <td>This is a notice of some action that has been taken or is about to be taken (i.e., no discussion or consensus is needed)
       <td>No
       <td>NA
     </tr>

--- a/bylaws.html
+++ b/bylaws.html
@@ -309,9 +309,9 @@
 
 <h3 id="rfc">3.6 Request For Comment (RFC) process</h3>
 
-For major changes to the fuctionality of CouchDB, a Request For Comment (RFC) process has been established. The intent of an RFC is to ensure sufficient public discussion has occurred on the design of new features, that the proposal is adequately captured in a summary document, and that there is community acceptance of the proposal. The completed RFC template for the proposal then becomes the basis for the new functionality's documentation.
+<p>For major changes to the fuctionality of CouchDB, a Request For Comment (RFC) process has been established. The intent of an RFC is to ensure sufficient public discussion has occurred on the design of new features, that the proposal is adequately captured in a summary document, and that there is community acceptance of the proposal. The completed RFC template for the proposal then becomes the basis for the new functionality's documentation.</p>
 
-The process is:
+<p>The process is:</p>
 
   <ul>
     <li>Start a [DISCUSS] thread on <a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">the developer mailing list</a>. Discuss your proposal in detail, including which modules/applications are affected, any HTTP API additions and deprecations, and security issues.</li>

--- a/bylaws.html
+++ b/bylaws.html
@@ -127,8 +127,6 @@
 
 <p>The Chair is elected by the PMC but appointed by the ASF Board via a Board resolution. The Chair is an officer of the Apache Software Foundation (with an official title of <em>Vice President, Apache CouchDB</em>) and has primary responsibility to the Board for the management of the project. The Chair is the eyes and ears of the Board, and reports quarterly on developments within the project.
 
-<p>The chair has primary responsibility to the Board, and has the power to establish rules and procedures for the day to day management of the communities for which the PMC is responsible, including the composition of the PMC itself.
-
 <p>Remember that, as in any meeting, the Chair is a facilitator and their role within the PMC is to ensure that everyone has a chance to be heard and to enable meetings to flow smoothly.
 
 <p>If the current Chair resigns, or the term of the Chair expires, the PMC will hold a Chair election.

--- a/bylaws.html
+++ b/bylaws.html
@@ -264,17 +264,11 @@
 
   <ul>
     <li>RTC (see section 3.5)
-      <ul>
-	<li>Requires one binding +1 vote and no vetos
-      </ul>
+      <ul><li>Requires one binding +1 vote and no vetos</ul>
     <li>Lazy majority
-      <ul>
-	<li>Requires three binding +1 votes and more binding +1 votes than binding -1 votes
-      </ul>
+      <ul><li>Requires three binding +1 votes and more binding +1 votes than binding -1 votes</ul>
     <li>Lazy 2/3 majority
-      <ul>
-	<li>Requires three binding +1 votes and twice as many binding +1 votes as binding -1 votes
-      </ul>
+      <ul><li>Requires three binding +1 votes and twice as many binding +1 votes as binding -1 votes</ul>
   </ul>
 
 <p>RTC is only ever used in the context of a code review or a pull request and does not require a separate vote thread. Each of the other approval models requires a vote thread.
@@ -360,11 +354,10 @@
     </tr>
     <tr>
       <td>Non-technical decision
-      <td>
-	A non-technical decision is any other sort of change or decision that falls outside of the other decision types. It is a catch-all decision type.
-	<br>
-	<br>
-	It is preferable that you make non-technical decisions via lazy consensus or discussion-led consensus-building.
+      <td>A non-technical decision is any other sort of change or decision that falls outside of the other decision types. It is a catch-all decision type.
+        <br>
+        <br>
+        It is preferable that you make non-technical decisions via lazy consensus or discussion-led consensus-building.
       <td>Whichever mailing list is most appropriate
       <td>Allowed
       <td>Lazy majority
@@ -374,11 +367,10 @@
     </tr>
     <tr>
       <td>Challenge a veto
-      <td>
-	Challenge the validity of a veto.
-	<br>
-	<br>
-	A veto is only valid when the caster has justified it with a sound technical argument.
+      <td>Challenge the validity of a veto.
+        <br>
+        <br>
+        A veto is only valid when the caster has justified it with a sound technical argument.
       <td><a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">Main development list</a>
       <td>No
       <td>Lazy 2/3 majority
@@ -388,11 +380,10 @@
     </tr>
     <tr>
       <td>New release
-      <td>
-	Make an official release.
-	<br>
-	<br>
-	Anyone can prepare release candidates.
+      <td>Make an official release.
+        <br>
+        <br>
+        Anyone can prepare release candidates.
       <td><a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">Main development list</a>
       <td>No
       <td>Lazy majority
@@ -402,11 +393,10 @@
     </tr>
     <tr>
       <td>New committer
-      <td>
-	Elect a new committer.
-	<br>
-	<br>
-	Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
+      <td>Elect a new committer.
+        <br>
+        <br>
+        Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy majority
@@ -416,11 +406,10 @@
     </tr>
     <tr>
       <td>New PMC member
-      <td>
-	Elect a new PMC member.
-	<br>
-	<br>
-	Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
+      <td>Elect a new PMC member.
+        <br>
+        <br>
+        Anyone can make nominations by emailing <a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">the private list</a>.
       <td><a href="https://mail-search.apache.org/pmc/private-arch/couchdb-private/">Private list</a>
       <td>No
       <td>Lazy 2/3 majority


### PR DESCRIPTION
this PR makes two changes:

- Add explicit `<p>` elements to fix display issue

- Remove redundant and potentially confusing paragraph about the chair

  The first sentence of this paragraph repeats some of the text in the previous paragraph. The second sentence covers powers and responsibilities shared with the PMC, and stating this in this section runs the risk of implying that the chair has special powers, which is not the case. (See § 3.8. Decision Types)

- General copyedit for style, grammar, spelling, etc.

- Detab the file and fix some minor HTML formatting issues

because this is a change to the bylaws, the PR requires voting and a lazy 2/3 majority (binding votes: PMC members) to pass