### PR TITLE
Fixed Addon URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,7 +320,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             <ul>
               <li>&mdash; <a href="fauxton-visual-guide/index.html">Fauxton, a Visual Guide</a></li>
               <li>&mdash; <a href="https://github.com/apache/couchdb-fauxton">Fauxton on GitHub</a></li>
-              <li>&mdash; <a href="http://docs.couchdb.org/en/latest/fauxton/addons.html">Writing an Addon</a></li>
+              <li>&mdash; <a href=https://docs.couchdb.org/en/latest/fauxton/install.html?highlight=Addon#understanding-fauxton-code-layout>Writing an Addon</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
Noticed that on the current version of the website, writing an addon URL leads to a site that states page doesn't exist. Updated the URL to lead to the CouchDB fauxton documentation on addons. This is my first time contributing so was not sure about branch naming conventions so do let me know. 