### PR TITLE
Update 3.2.1 release download links

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
       </ul>
 
       <div class="button-container">
-        <a class="button" href="#download">DOWNLOAD<small class="download-version">3.2.0 (2021-10-12)</small></a>
+        <a class="button" href="#download">DOWNLOAD<small class="download-version">3.2.1 (2021-11-06)</small></a>
       </div>
 
     </div>
@@ -542,7 +542,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
   <hr>
 
   <div class="wrap download-pane">
-    <h2 class="icon icon-download">Download CouchDB 3.2.0</h2>
+    <h2 class="icon icon-download">Download CouchDB 3.2.1</h2>
   </div>
 
   <div class="grid">
@@ -555,13 +555,13 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
         <ul class="list download-list">
           <li>
-            <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/3.2.0/apache-couchdb-3.2.0.tar.gz" class="type">Source</a>
+            <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz" class="type">Source</a>
             <span class="info">
-              Version 3.2.0 |
-              <a href="http://docs.couchdb.org/en/3.2.0/whatsnew/3.2.html#version-3.2.0" class="release">Release Notes</a> |
-              <a href="https://www.apache.org/dist/couchdb/source/3.2.0/apache-couchdb-3.2.0.tar.gz.asc">PGP Signature</a> |
-              <a href="https://www.apache.org/dist/couchdb/source/3.2.0/apache-couchdb-3.2.0.tar.gz.sha256">SHA256</a> |
-              <a href="https://www.apache.org/dist/couchdb/source/3.2.0/apache-couchdb-3.2.0.tar.gz.sha512">SHA512</a>
+              Version 3.2.1 |
+              <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1" class="release">Release Notes</a> |
+              <a href="https://www.apache.org/dist/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz.asc">PGP Signature</a> |
+              <a href="https://www.apache.org/dist/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz.sha256">SHA256</a> |
+              <a href="https://www.apache.org/dist/couchdb/source/3.2.1/apache-couchdb-3.2.1.tar.gz.sha512">SHA512</a>
             </span>
           </li>
           <li>
@@ -584,8 +584,8 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
           <li>
             <a href="http://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
-              Erlang/OTP 20.3.8.25 | Version 3.2.0 |
-            <a href="http://docs.couchdb.org/en/3.2.0/whatsnew/3.2.html#version-3.2.0" class="release">Release Notes</a>
+              Erlang/OTP 23.3.4.10 | Version 3.2.1 |
+            <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1" class="release">Release Notes</a>
             </span>
           </li>
         </ul>


### PR DESCRIPTION
A few convenience binaries are at 3.2.0, left those as is.