### PR TITLE
Update links and other small fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -788,7 +788,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
   <div id="footer">
 
-    <p>Copyright &copy; 2022 The Apache Software Foundation &ndash; Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
+    <p>Copyright &copy; 2022 The Apache Software Foundation &mdash; Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
       Apache CouchDB, CouchDB, and the project logo are <a href="https://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation</p>
 
     <a class="conf" href="https://www.apache.org/events/current-event.html"></a>

--- a/index.html
+++ b/index.html
@@ -788,7 +788,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
   <div id="footer">
 
-    <p>Copyright &copy; 2021 The Apache Software Foundation &mdash; Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
+    <p>Copyright &copy; 2022 The Apache Software Foundation &ndash; Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
       Apache CouchDB, CouchDB, and the project logo are <a href="https://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation</p>
 
     <a class="conf" href="https://www.apache.org/events/current-event.html"></a>

--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/3.2.2/apache-couchdb-3.2.2.tar.gz" class="type">Source</a>
             <span class="info">
               Version 3.2.2 |
-              <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-2" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.2.2/apache-couchdb-3.2.2.tar.gz.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.2.2/apache-couchdb-3.2.2.tar.gz.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.2.2/apache-couchdb-3.2.2.tar.gz.sha512">SHA512</a>
@@ -570,7 +570,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 23.3.4.13 | Version 3.2.2 |
-              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3-2-2" class="release">Release Notes</a>
             </span>
           </li>
           <li>
@@ -579,13 +579,13 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 24.3.1 | Version 3.2.2 |
-              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3-2-2" class="release">Release Notes</a>
             </span>
           <li>
             <a href="https://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
               Erlang/OTP 23.3.4.10 | Version 3.2.2 |
-            <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1" class="release">Release Notes</a>
+            <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-2" class="release">Release Notes</a>
             </span>
           </li>
         </ul>
@@ -617,7 +617,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz" class="type">Source</a>
             <span class="info">
               Version 3.1.2 |
-              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3-1-2" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.sha512">SHA512</a>
@@ -629,7 +629,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 20.3.8.25 | Version 3.1.2 |
-              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3-1-2" class="release">Release Notes</a>
             </span>
           </li>
           <li>
@@ -638,13 +638,13 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 22.2 | Version 3.1.2 |
-              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3-1-2" class="release">Release Notes</a>
             </span>
           <li>
             <a href="https://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
               Erlang/OTP 20.3.8.25 | Version 3.1.2 |
-            <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+            <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3-1-2" class="release">Release Notes</a>
             </span>
           </li>
         </ul>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
     </p>
 
-      <p>See the <a href="https://docs.couchdb.org/en/stable/intro/why.html">introduction</a>, <a href="https://docs.couchdb.org/en/stable/intro/overview.html">technical overview</a> for more information, or learn <a href="https://docs.couchdb.org/en/latest/whatsnew/3.1.html">what’s new in 3.1</a>.</p>
+      <p>See the <a href="https://docs.couchdb.org/en/stable/intro/why.html">introduction</a>, <a href="https://docs.couchdb.org/en/stable/intro/overview.html">technical overview</a> for more information, or learn <a href="https://docs.couchdb.org/en/latest/whatsnew/3.2.html">what’s new in 3.2</a>.</p>
 
     </div>
 

--- a/index.html
+++ b/index.html
@@ -134,7 +134,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
       <p>
 
-        Apache CouchDB™ lets you access your data where you need it. The <strong><a href="https://docs.couchdb.org/en/stable/replication/protocol.html" title="Couch Replication Protocol">Couch Replication Protocol</a></strong> is implemented in a variety of projects and products that span every imaginable computing environment from <strong>globally distributed server-clusters</strong>, over <strong>mobile phones</strong> to <strong>web browsers</strong>.
+        Apache CouchDB &trade; lets you access your data where you need it. The <strong><a href="https://docs.couchdb.org/en/stable/replication/protocol.html" title="Couch Replication Protocol">Couch Replication Protocol</a></strong> is implemented in a variety of projects and products that span every imaginable computing environment from <strong>globally distributed server-clusters</strong>, over <strong>mobile phones</strong> to <strong>web browsers</strong>.
 
       </p>
       <p>

--- a/index.html
+++ b/index.html
@@ -451,8 +451,8 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
               on CouchDB development.
             </p>
             <ul>
-              <li>&mdash; <a href="irc://irc.libera.chat/#couchdb">#CouchDB</a></li>
-              <li>&mdash; <a href="irc://irc.libera.chat/#couchdb-dev/">#CouchDB-dev</a></li>
+              <li>&mdash; <a href="https://web.libera.chat/#couchdb">#CouchDB</a></li>
+              <li>&mdash; <a href="https://web.libera.chat/#couchdb-dev/">#CouchDB-dev</a></li>
             </ul>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -797,29 +797,6 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
   </div>
 
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', 'UA-658988-6']);
-    _gaq.push(['_setDomainName', 'apache.org']);
-    _gaq.push(['_setAllowLinker', true]);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
-  </script>
-  <script>
-    $(document).ready(function () {
-      $('.download-list').on('click', function (e) {
-        if (!$(e.target).attr('href')) {
-          return;
-        }
-        _gaq.push(['_trackEvent', 'Click', 'Download', $(e.target).attr('href')]);
-      });
-    });
-  </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
 
 <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
 
-<link rel="canonical" href="http://couchdb.apache.org/"/>
+<link rel="canonical" href="https://couchdb.apache.org/"/>
 
 <title>Apache CouchDB</title>
 
@@ -44,9 +44,9 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
       <div class="menu">
         <a href="#about">About</a>
-        <a href="http://docs.couchdb.org">Docs</a>
+        <a href="https://docs.couchdb.org">Docs</a>
         <a href="#contribute">Contribute</a>
-        <a href="http://blog.couchdb.org">News</a>
+        <a href="https://blog.couchdb.org">News</a>
         <a href="#download">Download</a>
         <a href="#more">More&hellip;</a>
       </div>
@@ -56,9 +56,9 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
           <option value="">Menu</option>
           <option value="">----</option>
           <option value="#about">About</option>
-          <option value="http://docs.couchdb.org">Docs</option>
+          <option value="https://docs.couchdb.org">Docs</option>
           <option value="#contribute">Contribute</option>
-          <option value="http://blog.couchdb.org">News</option>
+          <option value="https://blog.couchdb.org">News</option>
           <option value="#download">Download</option>
           <option value="#more">More&hellip;</option>
         </select>
@@ -134,7 +134,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
       <p>
 
-        Apache CouchDB™ lets you access your data where you need it. The <strong><a href="http://docs.couchdb.org/en/stable/replication/protocol.html" title="Couch Replication Protocol">Couch Replication Protocol</a></strong> is implemented in a variety of projects and products that span every imaginable computing environment from <strong>globally distributed server-clusters</strong>, over <strong>mobile phones</strong> to <strong>web browsers</strong>.
+        Apache CouchDB™ lets you access your data where you need it. The <strong><a href="https://docs.couchdb.org/en/stable/replication/protocol.html" title="Couch Replication Protocol">Couch Replication Protocol</a></strong> is implemented in a variety of projects and products that span every imaginable computing environment from <strong>globally distributed server-clusters</strong>, over <strong>mobile phones</strong> to <strong>web browsers</strong>.
 
       </p>
       <p>
@@ -144,11 +144,11 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
       </p>
       <p>
 
-        <strong><a href="http://docs.couchdb.org/en/stable/replication/protocol.html" title="CouchDB Replication Protocol">The Couch Replication Protocol</a></strong> lets your data flow seamlessly between server clusters to mobile phones and web browsers, enabling a compelling <strong><a href="http://offlinefirst.org">offline-first</a></strong> user-experience while maintaining high performance and strong reliability. CouchDB comes with a <strong>developer-friendly</strong> query language, and optionally MapReduce for simple, efficient, and comprehensive data retrieval.
+        <strong><a href="https://docs.couchdb.org/en/stable/replication/protocol.html" title="CouchDB Replication Protocol">The Couch Replication Protocol</a></strong> lets your data flow seamlessly between server clusters to mobile phones and web browsers, enabling a compelling <strong><a href="https://offlinefirst.org">offline-first</a></strong> user-experience while maintaining high performance and strong reliability. CouchDB comes with a <strong>developer-friendly</strong> query language, and optionally MapReduce for simple, efficient, and comprehensive data retrieval.
 
     </p>
 
-      <p>See the <a href="http://docs.couchdb.org/en/stable/intro/why.html">introduction</a>, <a href="http://docs.couchdb.org/en/stable/intro/overview.html">technical overview</a> for more information, or learn <a href="http://docs.couchdb.org/en/latest/whatsnew/3.1.html">what’s new in 3.1</a>.</p>
+      <p>See the <a href="https://docs.couchdb.org/en/stable/intro/why.html">introduction</a>, <a href="https://docs.couchdb.org/en/stable/intro/overview.html">technical overview</a> for more information, or learn <a href="https://docs.couchdb.org/en/latest/whatsnew/3.1.html">what’s new in 3.1</a>.</p>
 
     </div>
 
@@ -217,8 +217,8 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </h3>
             <p class="skill-card-slogan">
 
-              CouchDB’s unique <a href="http://docs.couchdb.org/en/stable/replication/protocol.html">Replication Protocol</a> is the
-              foundation for a whole new generation of <a href="http://offlinefirst.org/">“Offline
+              CouchDB’s unique <a href="https://docs.couchdb.org/en/stable/replication/protocol.html">Replication Protocol</a> is the
+              foundation for a whole new generation of <a href="https://offlinefirst.org/">“Offline
               First”</a> applications for Mobile applications and other environments with <a
               href="https://www.youtube.com/watch?v=1sLjWlWvCsc">challenging
               network infrastructures</a>.
@@ -280,7 +280,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
     <div class="wrap">
       <h2 class="icon icon-contribute">Want to Contribute?</h2>
 
-      <p><strong>We welcome your contributions. </strong>CouchDB is an open source project. Everything, from this website to the core of the database itself, has been contributed by helpful individuals. The time and attention of our contributors is our most precious resource, and we always need more of it. Our primary goal is to build a welcoming, supporting, inclusive and diverse community. We abide by <a href="http://couchdb.apache.org/conduct.html">Code of Conduct</a> and a set of <a href="http://couchdb.apache.org/bylaws.html">Project Bylaws</a>. Come join us!
+      <p><strong>We welcome your contributions. </strong>CouchDB is an open source project. Everything, from this website to the core of the database itself, has been contributed by helpful individuals. The time and attention of our contributors is our most precious resource, and we always need more of it. Our primary goal is to build a welcoming, supporting, inclusive and diverse community. We abide by <a href="https://couchdb.apache.org/conduct.html">Code of Conduct</a> and a set of <a href="https://couchdb.apache.org/bylaws.html">Project Bylaws</a>. Come join us!
       </p>
     </div>
     <div class="grid contribute">
@@ -301,7 +301,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
               <li>&mdash; <a href="https://github.com/apache/couchdb">CouchDB on GitHub</a></li>
               <li>&mdash; <a href="https://github.com/apache/couchdb/issues">GitHub Issues</a></li>
               <li>&mdash; <a href="https://issues.apache.org/jira/browse/COUCHDB/?selectedTab=com.atlassian.jira.jira-projects-plugin:issues-panel">(Inactive) Jira issues</a></li>
-              <li>&mdash; <a href="http://mail-archives.apache.org/mod_mbox/couchdb-dev/">Dev mailing list</a></li>
+              <li>&mdash; <a href="https://mail-archives.apache.org/mod_mbox/couchdb-dev/">Dev mailing list</a></li>
             </ul>
           </div>
         </div>
@@ -338,7 +338,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </p>
             <ul>
               <li>&mdash; <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Meetups">CouchDB Meetups</a></li>
-              <li>&mdash; <a href="http://mail-archives.apache.org/mod_mbox/couchdb-marketing/">Marketing Mailing List</a></li>
+              <li>&mdash; <a href="https://mail-archives.apache.org/mod_mbox/couchdb-marketing/">Marketing Mailing List</a></li>
               <li>&mdash; <a href="https://twitter.com/CouchDB">Tweet us a link</a></li>
             </ul>
           </div>
@@ -360,8 +360,8 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </p>
             <ul>
               <li>&mdash; <a href="https://github.com/apache/couchdb-www">Website on GitHub</a></li>
-              <li>&mdash; <a href="http://mail-archives.apache.org/mod_mbox/couchdb-marketing/">Marketing mailing list</a></li>
-              <li>&mdash; <a href="http://mail-archives.apache.org/mod_mbox/couchdb-www/">Website mailing list</a></li>
+              <li>&mdash; <a href="https://mail-archives.apache.org/mod_mbox/couchdb-marketing/">Marketing mailing list</a></li>
+              <li>&mdash; <a href="https://mail-archives.apache.org/mod_mbox/couchdb-www/">Website mailing list</a></li>
             </ul>
           </div>
         </div>
@@ -476,12 +476,12 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
       <br/>
 
       <div class="list-header">
-        <a href="http://mail-archives.apache.org/mod_mbox/couchdb-announce/"><strong>Mail Search</strong></a>
+        <a href="https://mail-archives.apache.org/mod_mbox/couchdb-announce/"><strong>Mail Search</strong></a>
         <p>Search all of our mailing lists at once.</p>
       </div>
 
       <div class="list mailing-list">
-        <form action="http://markmail.org/search/list:org.apache.couchdb-*">
+        <form action="https://markmail.org/search/list:org.apache.couchdb-*">
           <input id="search-box" type="text" placeholder="Search query&hellip;" name="q" size="50"><button id="search-button"></button>
         </form>
       </div>
@@ -570,7 +570,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 23.3.4.13 | Version 3.2.2 |
-              <a href="http://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
             </span>
           </li>
           <li>
@@ -579,10 +579,10 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 24.3.1 | Version 3.2.2 |
-              <a href="http://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.2.2/whatsnew/3.2.html#version-3.2.2" class="release">Release Notes</a>
             </span>
           <li>
-            <a href="http://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
+            <a href="https://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
               Erlang/OTP 23.3.4.10 | Version 3.2.2 |
             <a href="https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1" class="release">Release Notes</a>
@@ -617,7 +617,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz" class="type">Source</a>
             <span class="info">
               Version 3.1.2 |
-              <a href="http://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/source/3.1.2/apache-couchdb-3.1.2.tar.gz.sha512">SHA512</a>
@@ -629,7 +629,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 20.3.8.25 | Version 3.1.2 |
-              <a href="http://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
             </span>
           </li>
           <li>
@@ -638,13 +638,13 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 22.2 | Version 3.1.2 |
-              <a href="http://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+              <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
             </span>
           <li>
-            <a href="http://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
+            <a href="https://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
               Erlang/OTP 20.3.8.25 | Version 3.1.2 |
-            <a href="http://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
+            <a href="https://docs.couchdb.org/en/3.1.2/whatsnew/3.1.html#version-3.1.2" class="release">Release Notes</a>
             </span>
           </li>
         </ul>
@@ -676,7 +676,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             <a href="https://www.apache.org/dyn/closer.lua?path=/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz" class="type">Source</a>
             <span class="info">
               Version 2.3.1 |
-              <a href="http://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/source/2.3.1/apache-couchdb-2.3.1.tar.gz.sha512">SHA512</a>
@@ -688,7 +688,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 19.3 | Version 2.3.1 |
-              <a href="http://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/win/2.3.1/apache-couchdb-2.3.1.msi.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/win/2.3.1/apache-couchdb-2.3.1.msi.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/win/2.3.1/apache-couchdb-2.3.1.msi.sha512">SHA512</a>
@@ -700,17 +700,17 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </a>
             <span class="info">
               Erlang/OTP 19.3 | Version 2.3.1 |
-              <a href="http://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
+              <a href="https://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/mac/2.3.1/Apache-CouchDB-2.3.1.zip.asc">PGP Signature</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/mac/2.3.1/Apache-CouchDB-2.3.1.zip.sha256">SHA256</a> |
               <a href="https://www.apache.org/dist/couchdb/binary/mac/2.3.1/Apache-CouchDB-2.3.1.zip.sha512">SHA512</a>
             </span>
           </li>
           <li>
-            <a href="http://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
+            <a href="https://docs.couchdb.org/en/latest/install/unix.html#installation-using-the-apache-couchdb-convenience-binary-packages" class="type">Debian/Ubuntu/RHEL/CentOS packages</a>
             <span class="info">
               Erlang/OTP 19.3 | Version 2.3.1 |
-            <a href="http://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a>
+            <a href="https://docs.couchdb.org/en/2.3.1/whatsnew/2.3.html#version-2.3.1" class="release">Release Notes</a>
             </span>
           </li>
         </ul>
@@ -753,17 +753,17 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
         <ul class="list more">
           <li class="corner"></li>
-          <li><a href="http://docs.couchdb.org">Documentation<span></span></a>
+          <li><a href="https://docs.couchdb.org">Documentation<span></span></a>
           <li><a href="https://cwiki.apache.org/confluence/display/COUCHDB/Current+Releases">Current Releases<span></span></a></li>
-          <li><a href="http://blog.couchdb.org/">Blog<span></span></a>
-          <li><a href="http://couchdb.apache.org/bylaws.html">Bylaws<span></span></a>
-          <li><a href="http://couchdb.apache.org/conduct.html">Code of Conduct<span></span></a>
+          <li><a href="https://blog.couchdb.org/">Blog<span></span></a>
+          <li><a href="https://couchdb.apache.org/bylaws.html">Bylaws<span></span></a>
+          <li><a href="https://couchdb.apache.org/conduct.html">Code of Conduct<span></span></a>
           <li><a href="https://cwiki.apache.org/confluence/display/COUCHDB/Professional+Services">Professional Services<span></span></a>
         </ul>
 
         <ul class="list more">
           <li class="corner"></li>
-          <li><a href="http://cwiki.apache.org/confluence/display/COUCHDB/">Wiki<span></span></a></li>
+          <li><a href="https://cwiki.apache.org/confluence/display/COUCHDB/">Wiki<span></span></a></li>
           <li><a href="https://github.com/apache/couchdb/issues">Issue Tracker<span></span></a></li>
           <li><a href="https://github.com/apache/couchdb/pulls">Pull Requests<span></span></a></li>
           <li><a href="https://github.com/apache?q=couchdb">Git Mirrors<span></span></a></li>
@@ -771,11 +771,11 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
         <ul class="list more last">
           <li class="corner"></li>
-          <li><a href="http://www.apache.org/">About the ASF<span></span></a></li>
-          <li><a href="http://www.apache.org/foundation/thanks.html">Thanks<span></span></a></li>
-          <li><a href="http://www.apache.org/foundation/sponsorship.html">Become a Sponsor<span></span></a></li>
-          <li><a href="http://www.apache.org/security/">Security<span></span></a></li>
-          <li><a href="http://www.apache.org/licenses/LICENSE-2.0">License<span></span></a></li>
+          <li><a href="https://www.apache.org/">About the ASF<span></span></a></li>
+          <li><a href="https://www.apache.org/foundation/thanks.html">Thanks<span></span></a></li>
+          <li><a href="https://www.apache.org/foundation/sponsorship.html">Become a Sponsor<span></span></a></li>
+          <li><a href="https://www.apache.org/security/">Security<span></span></a></li>
+          <li><a href="https://www.apache.org/licenses/LICENSE-2.0">License<span></span></a></li>
         </ul>
 
         <div class="clear"></div>
@@ -788,8 +788,8 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
 
   <div id="footer">
 
-    <p>Copyright &copy; 2021 The Apache Software Foundation &mdash; Licensed under the <a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
-      Apache CouchDB, CouchDB, and the project logo are <a href="http://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation</p>
+    <p>Copyright &copy; 2021 The Apache Software Foundation &mdash; Licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License 2.0</a><br>
+      Apache CouchDB, CouchDB, and the project logo are <a href="https://www.apache.org/foundation/marks/list/">trademarks</a> of The Apache Software Foundation</p>
 
     <a class="conf" href="https://www.apache.org/events/current-event.html"></a>
 

--- a/style/master.css
+++ b/style/master.css
@@ -366,7 +366,7 @@ blockquote {
   -webkit-transition: all 0.25s linear;
   -moz-transition: all 0.25s linear;
   transition: all 0.25s linear;
-  backround: #fff;
+  background: #fff;
   padding: 8px;
   width: 408px;
   font-size: 14px;

--- a/style/master.less
+++ b/style/master.less
@@ -421,7 +421,7 @@ blockquote {
 .mailing-list a {
     .list-link;
     .animate;
-    backround: #fff;
+    background: #fff;
     padding: @padding/2;
     width: @column + @gap*2 + @gutter;
     font-size: 14px;


### PR DESCRIPTION
- Update links to use https

- Fix typo in master.less/master.css

- Remove Google Analytics Code

- It's 2022 and a smaller dash

- Update whatsnew link to v3.2

- Update IRC links

- Update tm

- Update/fix release notes links to go to correct anker