### PR TITLE
Correct RFC template link

### DIFF
--- a/bylaws.html
+++ b/bylaws.html
@@ -309,13 +309,13 @@
 
 <h3 id="rfc">3.6 Request For Comment (RFC) process</h3>
 
-For major changes to the fuctionality of CouchDB, a Request For Comment (RFC) process has been established. The intent of an RFC is to ensure sufficient public discussion has occurred on the design of new features, that the proposal is adequately captured in a summary document, and that there is community acceptance of the proposal. The completed RFC template for the proposal then becomes the basis for the new functionality's documentation.
+<p>For major changes to the functionality of CouchDB, a Request For Comment (RFC) process has been established. The intent of an RFC is to ensure sufficient public discussion has occurred on the design of new features, that the proposal is adequately captured in a summary document, and that there is community acceptance of the proposal. The completed RFC template for the proposal then becomes the basis for the new functionality's documentation.</p>
 
-The process is:
+<p>The process is:</p>
 
   <ul>
     <li>Start a [DISCUSS] thread on <a href="https://lists.apache.org/list.html?dev@couchdb.apache.org">the developer mailing list</a>. Discuss your proposal in detail, including which modules/applications are affected, any HTTP API additions and deprecations, and security issues.</li>
-    <li>When there is consensus on the approach from the community, <a href="https://github.com/apache/couchdb-documentation/blob/main/rfcs/template.md">complete the RFC template</a> and work through any final revisions to the document, with the support of the developer mailing list.</li>
+    <li>When there is consensus on the approach from the community, <a href="https://github.com/apache/couchdb/blob/main/src/docs/rfcs/template.md">complete the RFC template</a> and work through any final revisions to the document, with the support of the developer mailing list.</li>
     <li>Start the RFC <strong>vote</strong> on the developer mailing list. Hold the vote according to the <em>lazy majority process</em>: at least 3 +1 votes, and more binding +1 than binding -1 votes.</li>
   </ul>
 


### PR DESCRIPTION
After moving the couchdb documentation site into the main couchdb repo, the RFC link in the bylaws was out of date.

Paragraph tags are also added to the RFC intro paragraph to ensure the text wraps the same way as other paragraphs in the document.