### PR TITLE
Update Erlang version for Windows binary

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,7 +570,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
               Windows (x64)
             </a>
             <span class="info">
-              Erlang/OTP 24.3.4.7 | Version 3.3.3 |
+              Erlang/OTP 24.3.4.14 | Version 3.3.3 |
               <a href="https://docs.couchdb.org/en/latest/whatsnew/3.3.html#version-3-3-3" class="release">Release Notes</a>
             </span>
           </li>


### PR DESCRIPTION
Submitted the wrong Erlang version in the [VOTE](https://lists.apache.org/thread/obn283mbnv7c3b4x5dx75jr0qvpr7p0d) Thread, it's 24.3.4.14.