### PR TITLE
Update docs url (point to main repo)

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
             </p>
             <ul>
               <li>&mdash; <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Apache+CouchDB+Wiki">CouchDB wiki</a></li>
-              <li>&mdash; <a href="https://github.com/apache/couchdb-documentation">Docs on GitHub</a></li>
+              <li>&mdash; <a href="https://github.com/apache/couchdb/tree/main/src/docs">Docs on GitHub</a></li>
               <li>&mdash; <a href="https://cwiki.apache.org/confluence/display/COUCHDB/Translation+Guide">Translation Guide</a></li>
             </ul>
           </div>


### PR DESCRIPTION
After migrating the docs from `couchdb-documentation` into the main CouchDB repo, we forgot to update the link.