### PR TITLE
Update index.html header to use “multi-primary”

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@ Thanks to Yohei Shimomae and the Apache Cordova team for the original design.
       <img src="image/couch@2x.png" alt=""/>
 
       <ul class="text-block">
-        <li><h1><strong>Seamless</strong> multi-master sync, that</h1></li>
+        <li><h1><strong>Seamless</strong> multi-primary sync, that</h1></li>
         <li><h1>scales from <strong>Big Data</strong> to <strong>Mobile,</strong></h1></li>
         <li><h1>with an <strong>Intuitive</strong> HTTP/JSON API</h1></li>
         <li><h1>and designed for <strong>Reliability.</strong></h1></li>


### PR DESCRIPTION
Hey, we’d like to slowly move away from language that is considered outdated and hostile. 

Based on its prevalence — and therefore recognisability —  I suggest “multi-primary” replaces “multi-master” in the hero header on the index page. This is inspired by the [Microsoft style guide](https://www.google.com/url?q=https://learn.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/m/master-slave&sa=D&source=docs&ust=1743508453594759&usg=AOvVaw0o2-YcwdexX9RLlf3Eec2J) standard.